### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,33 +23,33 @@
     "component"
   ],
   "dependencies": {
-    "hyphenate-style-name": "^1.0.0",
-    "lodash.omit": "^3.0.0",
-    "matchmedia": "^0.1.1",
-    "object-assign": "^2.0.0"
+    "hyphenate-style-name": "1.0.0",
+    "lodash.omit": "3.1.0",
+    "matchmedia": "0.1.2",
+    "object-assign": "2.1.1"
   },
   "peerDependencies": {
     "react": "*"
   },
   "devDependencies": {
-    "browserify": "^5.8.0",
-    "ecstatic": "^0.5.4",
-    "gulp": "^3.8.6",
+    "browserify": "5.13.1",
+    "ecstatic": "0.5.8",
+    "gulp": "3.9.0",
     "gulp-autowatch": "0.0.1",
-    "gulp-cached": "^1.0.1",
-    "gulp-gh-pages": "^0.3.3",
-    "gulp-jshint": "^1.7.1",
-    "gulp-livereload": "^2.1.0",
-    "gulp-sourcemaps": "^1.1.0",
-    "jshint": "^2.4.1",
-    "jshint-stylish": "^0.4.0",
-    "merge-stream": "^0.1.5",
-    "mocha": "^1.20.1",
-    "reactify": "^1.0.0",
-    "should": "^4.0.4",
+    "gulp-cached": "1.1.0",
+    "gulp-gh-pages": "0.3.4",
+    "gulp-jshint": "1.11.2",
+    "gulp-livereload": "2.1.1",
+    "gulp-sourcemaps": "1.5.2",
+    "jshint": "2.8.0",
+    "jshint-stylish": "0.4.0",
+    "merge-stream": "0.1.8",
+    "mocha": "1.21.5",
+    "reactify": "1.1.1",
+    "should": "4.6.5",
     "vinyl-buffer": "0.0.0",
-    "vinyl-source-stream": "^0.1.1",
-    "watchify": "^1.0.0"
+    "vinyl-source-stream": "0.1.1",
+    "watchify": "1.0.6"
   },
   "scripts": {
     "lint": "jshint ./src --reporter node_modules/jshint-stylish/stylish.js --exclude node_modules",


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>