### PR TITLE
Allow for react 0.14.0-rc1 as peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "object-assign": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "* || 0.14.0-rc1"
   },
   "devDependencies": {
     "browserify": "^5.8.0",


### PR DESCRIPTION
Otherwise npm v2 rejects the peer dependency. 