### PR TITLE
Do not require a component to wrap MediaQuery children

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,54 @@ var A = React.createClass({
 });
 ```
 
+### Component Property
+
+You may specify an optional `component` property on the `MediaQuery` that indicates what component to wrap children with. Any additional props defined on the `MediaQuery` will be passed through to this "wrapper" component. If the `component` property is not defined and the `MediaQuery` has more than 1 child, a `div` will be used as the "wrapper" component by default. However, if the `component` prop is not defined and there is only 1 child, that child will be rendered alone without a component wrapping it.
+
+**Specifying Wrapper Component**
+
+```jsx
+<MediaQuery minDeviceWidth={700} component="ul">
+  <li>Item 1</li>
+  <li>Item 2</li>
+</MediaQuery>
+
+// renders the following when the media query condition is met
+
+<ul>
+  <li>Item 1</li>
+  <li>Item 2</li>
+</ul>
+```
+
+**Unwrapped Component**
+
+```jsx
+<MediaQuery minDeviceWidth={700}>
+  <div>Unwrapped component</div>
+</MediaQuery>
+
+// renders the following when the media query condition is met
+
+<div>Unwrapped component</div>
+```
+
+**Default div Wrapper Component**
+
+```jsx
+<MediaQuery minDeviceWidth={1200} className="some-class">
+  <div>Wrapped</div>
+  <div>Content</div>
+</MediaQuery>
+
+// renders the following when the media query condition is met
+
+<div className="some-class">
+  <div>Wrapped</div>
+  <div>Content</div>
+</div>
+```
+
 ### Server rendering
 
 Server rendering can be done by passing static values through the `values` property.

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,11 @@ var mq = React.createClass({
         props,
         this.props.children
       );
+    } else if (props) {
+      return React.cloneElement(
+        this.props.children,
+        props
+      );
     } else {
       return this.props.children;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,6 @@ var mq = React.createClass({
 
   getDefaultProps: function(){
     return {
-      component: 'div',
       values: {}
     };
   },
@@ -87,7 +86,15 @@ var mq = React.createClass({
       return null;
     }
     var props = omit(this.props, excludedPropKeys);
-    return React.createElement(this.props.component, props, this.props.children);
+    if (this.props.component || this.props.children.length > 1) {
+      return React.createElement(
+        this.props.component || 'div',
+        props,
+        this.props.children
+      );
+    } else {
+      return this.props.children;
+    }
   }
 });
 


### PR DESCRIPTION
If a `props.component` was not explicitly defined and there is only 1 child inside the MediaQuery, just render the child instead of wrapping it in a div automatically.

This is a breaking change as it requires `props.component` to be explicitly defined if it only has one child, but it also provides more flexibility and makes it easier to limit unneeded "wrapper" DOM elements.

#### Example

The following:
```jsx
<MediaQuery query="(min-width: 700px)">
  <MyComponent />
</MediaQuery>
```

will render

```jsx
  <MyComponent />
```

instead of

```jsx
  <div>
    <MyComponent />
  </div>
```

but

```jsx
<MediaQuery query="(min-width: 700px)">
  <MyComponent />
  <MyComponent2 />
</MediaQuery>
```

still renders

```jsx
 <div>
    <MyComponent />
    <MyComponent2 />
  </div>
```