### PR TITLE
Doesn't throw error with empty children

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,8 @@ var mq = React.createClass({
     var hasMergeProps = Object.keys(props).length > 0;
     var wrapChildren = this.props.component ||
       React.Children.count(this.props.children) > 1 ||
-      typeof this.props.children === 'string';
+      typeof this.props.children === 'string' ||
+      this.props.children === undefined;
     if (wrapChildren) {
       return React.createElement(
         this.props.component || 'div',

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -100,7 +100,7 @@ describe('MediaQuery', function() {
     });
     it('throws if theres a bad query', function() {
       const mq = (
-        <MediaQuery>
+        <MediaQuery doesntExist='test'>
           <div className="childComponent"></div>
         </MediaQuery>
       );
@@ -116,4 +116,11 @@ describe('MediaQuery', function() {
     const e = TestUtils.renderIntoDocument(mq);
     assert.throws(() => (TestUtils.findRenderedDOMComponentWithClass(e, 'childComponent')), /Did not find exactly one match/);
   });
+  it('doesnt throw error when unspecificed component with empty children', function() {
+    const mq = (
+      <MediaQuery all className='parentBox' />
+    );
+    const e = TestUtils.renderIntoDocument(mq);
+    assert.isNotFalse(TestUtils.findRenderedDOMComponentWithClass(e, 'parentBox'));
+  })
 });


### PR DESCRIPTION
This address #57 , and adds a spec to demonstrate the behavior.

Also there is a small fix to a previous spec example: `throws if theres a bad query` which was the same example as `throws if theres no query`, so I made a small change to make it a "bad query".