### PR TITLE
Fix for Uncaught Invariant Violation #56. 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,8 +96,9 @@ var mq = React.createClass({
     }
     var props = omit(this.props, excludedPropKeys);
     var hasMergeProps = Object.keys(props).length > 0;
+    var childrenCount = React.Children.count(this.props.children);
     var wrapChildren = this.props.component ||
-      React.Children.count(this.props.children) > 1 ||
+      childrenCount > 1 ||
       typeof this.props.children === 'string' ||
       this.props.children === undefined;
     if (wrapChildren) {
@@ -111,8 +112,11 @@ var mq = React.createClass({
         this.props.children,
         props
       );
-    } else {
+    } else if (childrenCount){
       return this.props.children;
+    }
+    else {
+      return null;
     }
   }
 });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -106,6 +106,17 @@ describe('MediaQuery', function() {
       );
       assert.throws(() => (TestUtils.renderIntoDocument(mq)), 'Invalid or missing MediaQuery!');
     });
+    it('renders nothing when children is an empty array', function() {
+      const mq = (
+        <MediaQuery query="all">
+          {[].map((content, index) => {
+            return <div key={index}>{content}</div>
+          })}
+        </MediaQuery>
+      );
+      const e = TestUtils.renderIntoDocument(mq);
+      assert.equal(e.render(), null);
+    });
   });
   it('renders nothing when no matches', function() {
     const mq = (


### PR DESCRIPTION
Return null from render function when MediaQuery has no children.