### PR TITLE
Wrap children if it's single-element array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,7 @@ export default class MediaQuery extends React.Component {
     const wrapChildren = this.props.component ||
       childrenCount > 1 ||
       typeof this.props.children === 'string' ||
+      Array.isArray(this.props.children) && childrenCount == 1 ||
       this.props.children === undefined
     if (wrapChildren) {
       return React.createElement(

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -63,6 +63,15 @@ describe('MediaQuery', function() {
       const e = TestUtils.renderIntoDocument(mq);
       assert.isNotFalse(TestUtils.findRenderedDOMComponentWithTag(e, 'div'));
     });
+    it('renders a div when children is a single-element array', function() {
+      const mq = (
+        <MediaQuery query="all">
+          {['single element'].map((content, index) => <span key={index}>{content}</span>)}
+        </MediaQuery>
+      );
+      const e = TestUtils.renderIntoDocument(mq);
+      assert.isNotFalse(TestUtils.findRenderedDOMComponentWithTag(e, 'div'));
+    });
     it('passes extra props', function() {
       const mq = (
         <MediaQuery query="all" className="passedProp">


### PR DESCRIPTION
Spotted a bug today when passing single-element array as a children to `MediaQuery` causes error.
Multi-element arrays work fine, so this one looks like edge case.