### PR TITLE
move babel requirements into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,13 @@
     "component"
   ],
   "dependencies": {
+    "babel-core": "^6.18.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-runtime": "^6.15.0",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-es2015-loose": "^8.0.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-0": "^6.16.0",
     "babel-runtime": "^6.18.0",
     "hyphenate-style-name": "^1.0.0",
     "matchmedia": "^0.1.2"
@@ -34,15 +41,8 @@
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
-    "babel-core": "^6.18.0",
     "babel-eslint": "^7.1.0",
     "babel-loader": "^6.2.7",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-transform-runtime": "^6.15.0",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-es2015-loose": "^8.0.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
     "babel-register": "^6.18.0",
     "chai": "^3.5.0",
     "eslint": "^3.9.0",


### PR DESCRIPTION
we use `webpack` and `babel-loader` and explicitly exclude `/node_modules/` from babel-loader:

```
    test: /\.js$/,
    exclude: /node_modules/,
    loader: 'babel-loader',
```

 we now get this error:

```
10:54:49 client.1 | ERROR in ./~/react-responsive/src/mediaQuery.js
10:54:49 client.1 | Module parse failed: /Users/jon/git/instaflux/node_modules/react-responsive/src/mediaQuery.js Unexpected token (66:2)
10:54:49 client.1 | You may need an appropriate loader to handle this file type.
10:54:49 client.1 | SyntaxError: Unexpected token (66:2)
10:54:49 client.1 |     at Parser.pp$4.raise (/Users/jon/git/instaflux/node_modules/webpack/node_modules/acorn/dist/acorn.js:2221:15)
```

[that line](https://github.com/contra/react-responsive/blob/master/src/mediaQuery.js#L66) is using the es6 spread operator which requires [specific babel plugins / configuration](https://babeljs.io/docs/plugins/transform-object-rest-spread/).

we do use a babel config that supports this so i change my `babel-loader` to run for this module only (per [this](https://github.com/webpack/webpack/issues/2031#issuecomment-244921229))
```
    test: /\.js$/,
    exclude: /node_modules(?!\/react-responsive)/,
    loader: 'babel-loader',
```

then we got this error:
```
11:00:50 server.1 | Module build failed: Error: Couldn't find preset "stage-0" relative to directory "/Users/jon/git/instaflux/node_modules/react-responsive"
11:00:50 server.1 |     at /Users/jon/git/instaflux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:299:19
11:00:50 server.1 |     at Array.map (native)
11:00:50 server.1 |     at OptionManager.resolvePresets (/Users/jon/git/instaflux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:270:20)
11:00:50 server.1 |     at OptionManager.mergePresets (/Users/jon/git/instaflux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:259:10)
11:00:50 server.1 |     at OptionManager.mergeOptions (/Users/jon/git/instaflux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:244:14)
11:00:50 server.1 |     at OptionManager.init (/Users/jon/git/instaflux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:374:12)
11:00:50 server.1 |     at File.initOptions (/Users/jon/git/instaflux/node_modules/babel-core/lib/transformation/file/index.js:216:65)
11:00:50 server.1 |     at new File (/Users/jon/git/instaflux/node_modules/babel-core/lib/transformation/file/index.js:139:24)
11:00:50 server.1 |     at Pipeline.transform (/Users/jon/git/instaflux/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
11:00:50 server.1 |     at transpile (/Users/jon/git/instaflux/node_modules/babel-loader/lib/index.js:41:20)
11:00:50 server.1 |  @ ./components/Responsive.js 1:528-570
```
because those requirements are listed in [devDependencies](https://github.com/contra/react-responsive/blob/master/package.json#L35) they don't get installed when npm does its build.

this pr moves those into proper deps so that they work.

beyond that the es6 build probably deserves at least a minor version bump (if not major) - going from 1.2.1 -> 1.2.3 broke our app and required digging to solve. [react-helmet](https://github.com/nfl/react-helmet/pull/197) recently went through something similar..