### PR TITLE
Export toQuery function directly since src folder is no longer exported

### DIFF
--- a/dist/react-responsive.js
+++ b/dist/react-responsive.js
@@ -430,6 +430,7 @@ module.exports = exports['default'];
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.toQuery = exports.default = undefined;
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -606,7 +607,7 @@ MediaQuery.defaultProps = {
   values: {}
 };
 exports.default = MediaQuery;
-module.exports = exports['default'];
+exports.toQuery = _toQuery2.default;
 
 /***/ }),
 /* 8 */

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import hyphenate  from 'hyphenate-style-name'
 import mediaQuery from './mediaQuery'
 import toQuery  from './toQuery'
 
-
 const defaultTypes = {
   component: PropTypes.node,
   query: PropTypes.string,
@@ -24,7 +23,7 @@ function omit(object, keys) {
   return newObject
 }
 
-export default class MediaQuery extends React.Component {
+class MediaQuery extends React.Component {
   static displayName = 'MediaQuery'
   static defaultProps = {
     values: {}
@@ -134,3 +133,8 @@ export default class MediaQuery extends React.Component {
     }
   }
 }
+
+export {
+  MediaQuery as default,
+  toQuery
+};


### PR DESCRIPTION
Related to https://github.com/contra/react-responsive/issues/118
This exports the 'toQuery' function as the 'src' folder is no longer available directly.