### PR TITLE
bugfix: Invariant Violation: Element type is invalid:

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ class MediaQuery extends React.Component {
     const props = omit(this.props, excludedPropKeys)
     const hasMergeProps = Object.keys(props).length > 0
     const childrenCount = React.Children.count(this.props.children)
-    const wrapChildren = this.props.component || this.props.children == null
+    const wrapChildren = this.props.component || this.props.children == null || (hasMergeProps && childrenCount > 1)
     if (wrapChildren) {
       return React.createElement(
         this.props.component || 'div',
@@ -134,4 +134,3 @@ export {
   MediaQuery as default,
   toQuery
 }
-

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -73,6 +73,16 @@ describe('MediaQuery', function () {
       const e = TestUtils.renderIntoDocument(mq)
       assert.throws(() => (TestUtils.findRenderedDOMComponentWithTag(e, 'div')), /Did not find exactly one match/)
     })
+    it('render a div when there are extra props and multiple children', function () {
+      const mq = (
+        <MediaQuery query="all" className="wrapper">
+          <span className="childComponent"/>
+          <span className="childComponent"/>
+        </MediaQuery>
+      )
+      const e = TestUtils.renderIntoDocument(mq)
+      assert.isNotFalse(TestUtils.findRenderedDOMComponentWithTag(e, 'div'))
+    })
     it('renders the first child when children is a single-element array', function () {
       const mq = (
         <MediaQuery query="all">


### PR DESCRIPTION
expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

since `React.cloneElement` will return `undefined` when children count > 1