### PR TITLE
Use React.Fragment with multiple children instead of 'div'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ class MediaQuery extends React.Component {
     const wrapChildren = this.props.component || this.props.children == null || (hasMergeProps && childrenCount > 1)
     if (wrapChildren) {
       return React.createElement(
-        this.props.component || 'div',
+        this.props.component || React.Fragment,
         props,
         this.props.children
       )


### PR DESCRIPTION
Since peer dependency includes react 16, can make use of React.Fragment when multiple children are passed instead of wrapping it in another 'div'