### PR TITLE
Remove all custom children handling logic and simply return children.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,43 +127,9 @@ You may also specify a function for the child of the MediaQuery component. When 
 </MediaQuery>
 ```
 
-### Component Property
-
-You may specify an optional `component` property on the `MediaQuery` that indicates what component to wrap children with. Any additional props defined on the `MediaQuery` will be passed through to this "wrapper" component.
-
-**Specifying Wrapper Component**
-
-```jsx
-<MediaQuery minDeviceWidth={700} component="ul">
-  <li>Item 1</li>
-  <li>Item 2</li>
-</MediaQuery>
-
-// renders the following when the media query condition is met
-
-<ul>
-  <li>Item 1</li>
-  <li>Item 2</li>
-</ul>
-```
-
-**Normal Behavior**
-
-```jsx
-<MediaQuery minDeviceWidth={700}>
-  <div>Unwrapped content</div>
-  <div>Unwrapped content</div>
-</MediaQuery>
-
-// renders the following when the media query condition is met
-
-<div>Unwrapped content</div>
-<div>Unwrapped content</div>
-```
-
 ### Server rendering
 
-Server rendering can be done by passing static values through the `values` property. 
+Server rendering can be done by passing static values through the `values` property.
 
 The values property can contain `orientation`, `scan`, `aspectRatio`, `deviceAspectRatio`,
 `height`, `deviceHeight`, `width`, `deviceWidth`, `color`, `colorIndex`, `monochrome`,
@@ -174,7 +140,7 @@ The values property can contain `orientation`, `scan`, `aspectRatio`, `deviceAsp
 
 Note: The `values` property always takes precedence, even on the client where a `window` object exists and matchMedia can be used.
 
-If you are using [redux](http://redux.js.org/) you can automatically pass `width` / `deviceWidth` values to your components with [react-responsive-redux](https://github.com/modosc/react-responsive-redux). 
+If you are using [redux](http://redux.js.org/) you can automatically pass `width` / `deviceWidth` values to your components with [react-responsive-redux](https://github.com/modosc/react-responsive-redux).
 
 
 ```jsx

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,8 @@ const defaultTypes = {
   onChange: PropTypes.func,
   onBeforeChange: PropTypes.func
 }
-const mediaKeys = Object.keys(mediaQuery.all)
+
 const excludedQueryKeys = Object.keys(defaultTypes)
-const excludedPropKeys = excludedQueryKeys.concat(mediaKeys)
 
 function omit(object, keys) {
   const newObject = { ...object }
@@ -58,7 +57,7 @@ class MediaQuery extends React.Component {
           result[hyphenate(key)] = props.values[key]
           return result
         }, {})
-      if (Object.keys(values).length !== 0) forceStatic = true 
+      if (Object.keys(values).length !== 0) forceStatic = true
     }
 
     this.removeMql()
@@ -108,27 +107,8 @@ class MediaQuery extends React.Component {
     if (this.state.matches === false) {
       return null
     }
-    const props = omit(this.props, excludedPropKeys)
-    const hasMergeProps = Object.keys(props).length > 0
-    const childrenCount = React.Children.count(this.props.children)
-    const wrapChildren = this.props.component || this.props.children == null || (hasMergeProps && childrenCount > 1)
-    if (wrapChildren) {
-      return React.createElement(
-        this.props.component || 'div',
-        props,
-        this.props.children
-      )
-    } else if (hasMergeProps) {
-      return React.cloneElement(
-        this.props.children,
-        props
-      )
-    } else if (childrenCount) {
-      return this.props.children
-    }
-    else {
-      return null
-    }
+
+    return this.props.children
   }
 }
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -54,54 +54,6 @@ describe('MediaQuery', function () {
       const e = TestUtils.renderIntoDocument(mq)
       assert.throws(() => (TestUtils.findRenderedDOMComponentWithTag(e, 'div')), /Did not find exactly one match/)
     })
-    it('renders the wrapper', function () {
-      const mq = (
-        <MediaQuery query="all" component="section">
-          <div className="childComponent"/>
-        </MediaQuery>
-      )
-      const e = TestUtils.renderIntoDocument(mq)
-      assert.isNotFalse(TestUtils.findRenderedDOMComponentWithTag(e, 'section'))
-    })
-    it('does not render a div when there are multiple children', function () {
-      const mq = (
-        <MediaQuery query="all">
-          <span className="childComponent"/>
-          <span className="childComponent"/>
-        </MediaQuery>
-      )
-      const e = TestUtils.renderIntoDocument(mq)
-      assert.throws(() => (TestUtils.findRenderedDOMComponentWithTag(e, 'div')), /Did not find exactly one match/)
-    })
-    it('render a div when there are extra props and multiple children', function () {
-      const mq = (
-        <MediaQuery query="all" className="wrapper">
-          <span className="childComponent"/>
-          <span className="childComponent"/>
-        </MediaQuery>
-      )
-      const e = TestUtils.renderIntoDocument(mq)
-      assert.isNotFalse(TestUtils.findRenderedDOMComponentWithTag(e, 'div'))
-    })
-    it('renders the first child when children is a single-element array', function () {
-      const mq = (
-        <MediaQuery query="all">
-          {[ 'single element' ].map((content, index) => <span key={index}>{content}</span>)}
-        </MediaQuery>
-      )
-      const e = TestUtils.renderIntoDocument(mq)
-      assert.isNotFalse(TestUtils.findRenderedDOMComponentWithTag(e, 'span'))
-      assert.throws(() => (TestUtils.findRenderedDOMComponentWithTag(e, 'div')), /Did not find exactly one match/)
-    })
-    it('passes extra props', function () {
-      const mq = (
-        <MediaQuery query="all" className="passedProp">
-          <div/>
-        </MediaQuery>
-      )
-      const e = TestUtils.renderIntoDocument(mq)
-      assert.isNotFalse(TestUtils.findRenderedDOMComponentWithClass(e, 'passedProp'))
-    })
     it('uses query prop if it has one', function () {
       const mq = (
         <MediaQuery query="all" className="passedProp">
@@ -145,17 +97,6 @@ describe('MediaQuery', function () {
       )
       assert.throws(() => (TestUtils.renderIntoDocument(mq)), 'Invalid or missing MediaQuery!')
     })
-    it('renders nothing when children is an empty array', function () {
-      const mq = (
-        <MediaQuery query="all">
-          {[].map((content, index) => {
-            return <div key={index}>{content}</div>
-          })}
-        </MediaQuery>
-      )
-      const e = TestUtils.renderIntoDocument(mq)
-      assert.equal(e.render(), null)
-    })
   })
   it('renders nothing when no matches', function () {
     const mq = (
@@ -184,21 +125,6 @@ describe('MediaQuery', function () {
     const e = TestUtils.renderIntoDocument(mq)
     assert.throws(() => (TestUtils.findRenderedDOMComponentWithClass(e, 'childComponent')), /Did not find exactly one match/)
   })
-  it('doesnt throw error when unspecificed component with empty children', function () {
-    const mq = (
-      <MediaQuery all className="parentBox" />
-    )
-    const e = TestUtils.renderIntoDocument(mq)
-    assert.isNotFalse(TestUtils.findRenderedDOMComponentWithClass(e, 'parentBox'))
-  })
-  it('doesnt throw error when component with null children', function () {
-    const mq = (
-      <MediaQuery all className="parentBox">{null}</MediaQuery>
-    )
-    const e = TestUtils.renderIntoDocument(mq)
-    assert.isNotFalse(TestUtils.findRenderedDOMComponentWithClass(e, 'parentBox'))
-  })
-
   it('renders with output of callback', function () {
     const mq = (
       <MediaQuery maxWidth={300}>


### PR DESCRIPTION
In earlier versions of React it was necessary to wrap children in element in the event there was more than one child, but this is no longer necessary since react supports arrays and fragments now.  Wrappers can be specified as children and merge props can be specified with `{...mergeProps}` may not need to be this library's responsibility.

@contra, this is what I meant about simplifying the render. Feel free to close if you think its not worth the trouble. 
