### PR TITLE
Updated peerDependency of react to minimum 16.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v6.0.0
 
-- Require React v16 or higher
+- Require React v16.3.0 or higher
 - Update and simplify all lifecycle functions
 - Remove all support for wrapper elements
   - Previously, when either `component` or non-mediaquery props were provided, we would render a wrapper element. This behavior no longer exists.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
`getDerivedStateFromProps` has been added only for react 16.3.0 and up. Downloading the package and running it on a version < 16.3.0 emits console errors