### PR TITLE
Fix forceStatic Bug and check forceStatic on render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@ const defaultTypes = {
   component: PropTypes.node,
   query: PropTypes.string,
   values: PropTypes.shape(mediaQuery.matchers),
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-  onChange: PropTypes.func,
+  children: PropTypes.oneOfType([ PropTypes.node, PropTypes.func ]),
+  onChange: PropTypes.func
 }
 
 const excludedQueryKeys = Object.keys(defaultTypes)
@@ -21,46 +21,44 @@ const omit = (object, keys) => {
   return newObject
 }
 
-const getValues = ({ values = {} }) =>
+const getValues = ({ values={} }) =>
   Object.keys(values).reduce((result, key) => {
     result[hyphenate(key)] = values[key]
     return result
   }, {})
 
-const getQuery = props => props.query || toQuery(omit(props, excludedQueryKeys))
+const getQuery = (props) =>
+  props.query || toQuery(omit(props, excludedQueryKeys))
 
 const createMatchMedia = (props, query) => {
   const values = getValues(props)
-  const forceStatic = Object.keys(values).length !== 0
+  const forceStatic = Object.keys(values).length === 0
   return matchMedia(query, values, forceStatic)
 }
 
 class MediaQuery extends React.Component {
   static displayName = 'MediaQuery'
   static defaultProps = {
-    values: {},
+    values: {}
   }
 
   static getDerivedStateFromProps(props, state) {
     const query = getQuery(props)
     if (!query) throw new Error('Invalid or missing MediaQuery!')
-    const forceStatic = Object.keys(props.values).length !== 0
-    if (query === state.query && forceStatic === state.forceStatic) return null
+    if (query === state.query) return null
 
     const mq = createMatchMedia(props, query)
     return {
       matches: mq.matches,
       mq,
-      query,
-      forceStatic,
+      query
     }
   }
 
   state = {
     matches: false,
     mq: null,
-    query: '',
-    forceStatic: false,
+    query: ''
   }
 
   componentDidMount() {
@@ -87,7 +85,7 @@ class MediaQuery extends React.Component {
     this.cleanupMediaQuery(this.state.mq)
   }
 
-  cleanupMediaQuery = mq => {
+  cleanupMediaQuery = (mq) => {
     if (!mq) return
     mq.removeListener(this.updateMatches)
     mq.dispose()
@@ -107,4 +105,7 @@ class MediaQuery extends React.Component {
   }
 }
 
-export { MediaQuery as default, toQuery }
+export {
+  MediaQuery as default,
+  toQuery
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import matchMedia from 'matchmediaquery'
-import hyphenate  from 'hyphenate-style-name'
+import hyphenate from 'hyphenate-style-name'
 import mediaQuery from './mediaQuery'
-import toQuery  from './toQuery'
+import toQuery from './toQuery'
 
 const defaultTypes = {
   component: PropTypes.node,
   query: PropTypes.string,
   values: PropTypes.shape(mediaQuery.matchers),
-  children: PropTypes.oneOfType([ PropTypes.node, PropTypes.func ]),
-  onChange: PropTypes.func
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  onChange: PropTypes.func,
 }
 
 const excludedQueryKeys = Object.keys(defaultTypes)
@@ -21,44 +21,46 @@ const omit = (object, keys) => {
   return newObject
 }
 
-const getValues = ({ values={} }) =>
+const getValues = ({ values = {} }) =>
   Object.keys(values).reduce((result, key) => {
     result[hyphenate(key)] = values[key]
     return result
   }, {})
 
-const getQuery = (props) =>
-  props.query || toQuery(omit(props, excludedQueryKeys))
+const getQuery = props => props.query || toQuery(omit(props, excludedQueryKeys))
 
 const createMatchMedia = (props, query) => {
   const values = getValues(props)
-  const forceStatic = values.length === 0
+  const forceStatic = Object.keys(values).length !== 0
   return matchMedia(query, values, forceStatic)
 }
 
 class MediaQuery extends React.Component {
   static displayName = 'MediaQuery'
   static defaultProps = {
-    values: {}
+    values: {},
   }
 
   static getDerivedStateFromProps(props, state) {
     const query = getQuery(props)
     if (!query) throw new Error('Invalid or missing MediaQuery!')
-    if (query === state.query) return null
+    const forceStatic = Object.keys(props.values).length !== 0
+    if (query === state.query && forceStatic === state.forceStatic) return null
 
     const mq = createMatchMedia(props, query)
     return {
       matches: mq.matches,
       mq,
-      query
+      query,
+      forceStatic,
     }
   }
 
   state = {
     matches: false,
     mq: null,
-    query: ''
+    query: '',
+    forceStatic: false,
   }
 
   componentDidMount() {
@@ -85,7 +87,7 @@ class MediaQuery extends React.Component {
     this.cleanupMediaQuery(this.state.mq)
   }
 
-  cleanupMediaQuery = (mq) => {
+  cleanupMediaQuery = mq => {
     if (!mq) return
     mq.removeListener(this.updateMatches)
     mq.dispose()
@@ -105,7 +107,4 @@ class MediaQuery extends React.Component {
   }
 }
 
-export {
-  MediaQuery as default,
-  toQuery
-}
+export { MediaQuery as default, toQuery }


### PR DESCRIPTION
Fixes #194
Fix bug that makes forceStatic always evaluate to false.
Store forceStatic in state and check if it changes between renders for server side rendering.

This way we can use the value object to render on server and first render on client to get rid of "classnames do not match on server and client" warning. Then after first render we can re-render without the values object to use window object.