### PR TITLE
Use correct react globals

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,8 +40,18 @@ module.exports = {
   },
   devtool: 'source-map',
   externals: {
-    'react': 'umd react',
-    'react-dom': 'umd react-dom'
+    'react': {
+      commonjs: 'react',
+      commonjs2: 'react',
+      amd: 'react',
+      root: 'React'
+    },
+    'react-dom': {
+      commonjs: 'react-dom',
+      commonjs2: 'react-dom',
+      amd: 'react-dom',
+      root: 'ReactDOM'
+    }
   },
   plugins,
   resolve: {


### PR DESCRIPTION
This library's umd build does not work with react's because it refers to `react` instead of `React`.

Open the developer console to see the error.
https://jsfiddle.net/xa01mk53/
