### PR TITLE
Exposes toQuery function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import useMediaQuery from './useMediaQuery'
 import MediaQuery from './Component'
+import toQuery from './toQuery'
 import Context from './Context'
 
 export {
   MediaQuery as default,
   useMediaQuery,
+  toQuery,
   Context
 }

--- a/src/toQuery.js
+++ b/src/toQuery.js
@@ -21,7 +21,7 @@ const keyVal = (k, v) => {
 
 const join = (conds) => conds.join(' and ')
 
-export default (obj) => {
+const toQuery = (obj) => {
   const rules = []
   Object.keys(mq.all).forEach((k) => {
     const v = obj[k]
@@ -31,3 +31,5 @@ export default (obj) => {
   })
   return join(rules)
 }
+
+export default toQuery

--- a/test/toQuery_test.js
+++ b/test/toQuery_test.js
@@ -22,4 +22,8 @@ describe('toQuery', () => {
     const q = toQuery({ orientation: 'portrait', minWidth: 760 })
     assert.equal(q, '(min-width: 760px) and (orientation: portrait)')
   })
+  it('handles multiple query rules', () => {
+    const q = toQuery({ minWidth: 640, maxWidth: 760 })
+    assert.equal(q, '(min-width: 640px) and (max-width: 760px)')
+  })
 })


### PR DESCRIPTION
Most of the cases I could think of already had test cases for them in `test/toQuery_test.js`. I just added one with multiple media queries. I also made a `toQuery` variable in `src/toQuery.js` to help with readability.

Fixes #255 