### PR TITLE
fix: pass device to matchMedia for ssr

### DIFF
--- a/src/useMediaQuery.ts
+++ b/src/useMediaQuery.ts
@@ -62,7 +62,7 @@ const useQuery = (settings: MediaQuerySettings) => {
 }
 
 const useMatchMedia = (query: string, device: MediaQueryMatchers) => {
-  const getMatchMedia = () => matchMedia(query)
+  const getMatchMedia = () => matchMedia(query, device)
   const [ mq, setMq ] = React.useState(getMatchMedia)
   const isUpdate = useIsUpdate()
 


### PR DESCRIPTION
Hey, thanks for writing this library!

I was having issues with SSR using 9.0.0-beta.2. Looks like the device is passed to the `useEffect` dependency list below but not to `matchMedia` itself. It seems to be required for static `css-mediaquery` module that `matchmediaquery` uses under the hood. I was getting this error:

```
TypeError: Cannot read property 'width' of undefined
  at /node_modules/react-responsive/dist/react-responsive.js:211:130
```